### PR TITLE
Add project version configuration item

### DIFF
--- a/src/main/java/org/metersphere/AppSettingConfigurable.java
+++ b/src/main/java/org/metersphere/AppSettingConfigurable.java
@@ -15,9 +15,8 @@ import javax.swing.*;
  * 配置主类
  */
 public class AppSettingConfigurable implements Configurable {
-    //main setting pane
-    private AppSettingComponent appSettingComponent;
-    private AppSettingService appSettingService = ApplicationManager.getApplication().getComponent(AppSettingService.class);
+
+    private final AppSettingService appSettingService = AppSettingService.getInstance();
     private AppSettingState originalState;
 
     @Override
@@ -28,7 +27,8 @@ public class AppSettingConfigurable implements Configurable {
     @Override
     public @Nullable
     JComponent createComponent() {
-        appSettingComponent = new AppSettingComponent();
+        //main setting pane
+        AppSettingComponent appSettingComponent = new AppSettingComponent();
         originalState = JSONObject.parseObject(JSONObject.toJSONString(appSettingService.getState()), AppSettingState.class);
         return appSettingComponent.getSettingPanel();
     }

--- a/src/main/java/org/metersphere/AppSettingService.java
+++ b/src/main/java/org/metersphere/AppSettingService.java
@@ -1,5 +1,6 @@
 package org.metersphere;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -13,6 +14,10 @@ import org.metersphere.state.AppSettingState;
 @State(name = "metersphereState", storages = {@Storage("msstore.xml")})
 public class AppSettingService implements PersistentStateComponent<AppSettingState> {
     private AppSettingState appSettingState = new AppSettingState();
+
+    public static AppSettingService getInstance() {
+        return ApplicationManager.getApplication().getService(AppSettingService.class);
+    }
 
     @Override
     public @Nullable AppSettingState getState() {

--- a/src/main/java/org/metersphere/exporter/MeterSphereExporter.java
+++ b/src/main/java/org/metersphere/exporter/MeterSphereExporter.java
@@ -101,6 +101,7 @@ public class MeterSphereExporter implements IExporter {
         param.put("platform", "Postman");
         param.put("model", "definition");
         param.put("projectId", state.getProjectList().stream().filter(p -> p.getName().equalsIgnoreCase(state.getProjectName())).findFirst().get().getId());
+        param.put("versionId", state.getProjectVersion());
         HttpEntity formEntity = MultipartEntityBuilder.create().addBinaryBody("file", file, ContentType.APPLICATION_JSON, null)
                 .addBinaryBody("request", param.toJSONString().getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON, null).build();
 

--- a/src/main/java/org/metersphere/exporter/MeterSphereExporter.java
+++ b/src/main/java/org/metersphere/exporter/MeterSphereExporter.java
@@ -37,8 +37,8 @@ import java.util.stream.Collectors;
 
 public class MeterSphereExporter implements IExporter {
     private Logger logger = Logger.getInstance(MeterSphereExporter.class);
-    private PostmanExporter postmanExporter = new PostmanExporter();
-    private AppSettingService appSettingService = ApplicationManager.getApplication().getComponent(AppSettingService.class);
+    private final PostmanExporter postmanExporter = new PostmanExporter();
+    private final AppSettingService appSettingService = AppSettingService.getInstance();
 
     @Override
     public boolean export(PsiElement psiElement) throws IOException {

--- a/src/main/java/org/metersphere/exporter/PostmanExporter.java
+++ b/src/main/java/org/metersphere/exporter/PostmanExporter.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class PostmanExporter implements IExporter {
-    private AppSettingService appSettingService = ApplicationManager.getApplication().getComponent(AppSettingService.class);
+    private final AppSettingService appSettingService = AppSettingService.getInstance();
 
     @Override
     public boolean export(PsiElement psiElement) {
@@ -758,7 +758,7 @@ public class PostmanExporter implements IExporter {
         String javaType = pe.getType().getCanonicalText();
         PsiClass psiClass = JavaPsiFacade.getInstance(pe.getProject()).findClass(pe.getType().getCanonicalText(), GlobalSearchScope.allScope(pe.getProject()));
         LinkedHashMap param = new LinkedHashMap();
-        AppSettingState state = ApplicationManager.getApplication().getComponent(AppSettingService.class).getState();
+        AppSettingState state = AppSettingService.getInstance().getState();
         int maxDeepth = state.getDeepth();
         int curDeepth = 1;
         //这个判断对多层集合嵌套的数据类型
@@ -813,7 +813,7 @@ public class PostmanExporter implements IExporter {
         String javaType = pe.getType().getCanonicalText();
         PsiClass psiClass = JavaPsiFacade.getInstance(pe.getProject()).findClass(pe.getType().getCanonicalText(), GlobalSearchScope.allScope(pe.getProject()));
         LinkedHashMap param = new LinkedHashMap();
-        AppSettingState state = ApplicationManager.getApplication().getComponent(AppSettingService.class).getState();
+        AppSettingState state = AppSettingService.getInstance().getState();
         int maxDeepth = state.getDeepth();
         int curDeepth = 1;
         //这个判断对多层集合嵌套的数据类型

--- a/src/main/java/org/metersphere/gui/AppSettingComponent.form
+++ b/src/main/java/org/metersphere/gui/AppSettingComponent.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainSettingPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="520" height="502"/>
+      <xy x="20" y="20" width="612" height="502"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -17,7 +17,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="48125" layout-manager="GridLayoutManager" row-count="8" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="48125" layout-manager="GridLayoutManager" row-count="9" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <tabbedpane title="Base Setting"/>
@@ -37,7 +37,7 @@
               </component>
               <vspacer id="1d61b">
                 <constraints>
-                  <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                  <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
                     <maximum-size width="-1" height="1"/>
                   </grid>
                 </constraints>
@@ -86,7 +86,7 @@
               </component>
               <component id="90405" class="javax.swing.JButton" binding="testCon">
                 <constraints>
-                  <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="test"/>
@@ -95,7 +95,7 @@
               <grid id="64cbb" layout-manager="GridLayoutManager" row-count="4" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -248,6 +248,20 @@
                   <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
+              </component>
+              <component id="cec6d" class="javax.swing.JComboBox" binding="projectVersionCB">
+                <constraints>
+                  <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+              </component>
+              <component id="dd7bc" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="version"/>
+                </properties>
               </component>
             </children>
           </grid>

--- a/src/main/java/org/metersphere/gui/AppSettingComponent.java
+++ b/src/main/java/org/metersphere/gui/AppSettingComponent.java
@@ -39,7 +39,7 @@ public class AppSettingComponent {
     private JTextField moduleName;
     private JCheckBox javadocCheckBox;
     private JTextField contextPath;
-    private AppSettingService appSettingService = ApplicationManager.getApplication().getComponent(AppSettingService.class);
+    private AppSettingService appSettingService = AppSettingService.getInstance();
     private Gson gson = new Gson();
     private Logger logger = Logger.getInstance(AppSettingComponent.class);
 

--- a/src/main/java/org/metersphere/gui/AppSettingComponent.java
+++ b/src/main/java/org/metersphere/gui/AppSettingComponent.java
@@ -1,26 +1,36 @@
 package org.metersphere.gui;
 
+import static org.metersphere.utils.MSApiUtil.test;
+
 import com.alibaba.fastjson.JSONObject;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Messages;
+import java.awt.event.ItemEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
 import lombok.Data;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.metersphere.AppSettingService;
 import org.metersphere.state.AppSettingState;
 import org.metersphere.state.MSModule;
 import org.metersphere.state.MSProject;
+import org.metersphere.state.MSVersion;
 import org.metersphere.utils.MSApiUtil;
-
-import javax.swing.*;
-import java.awt.event.*;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.metersphere.utils.MSApiUtil.test;
 
 @Data
 public class AppSettingComponent {
@@ -39,6 +49,7 @@ public class AppSettingComponent {
     private JTextField moduleName;
     private JCheckBox javadocCheckBox;
     private JTextField contextPath;
+    private JComboBox<String> projectVersionCB;
     private AppSettingService appSettingService = AppSettingService.getInstance();
     private Gson gson = new Gson();
     private Logger logger = Logger.getInstance(AppSettingComponent.class);
@@ -56,8 +67,18 @@ public class AppSettingComponent {
         if (appSettingState.getProjectNameList() != null) {
             appSettingState.getProjectNameList().forEach(p -> projectNameCB.addItem(p));
         }
+        if (appSettingState.getVersionOptions() != null) {
+            appSettingState.getVersionOptions()
+                .forEach(version -> projectVersionCB.addItem(version.getName()));
+        }
         if (StringUtils.isNotBlank(appSettingState.getProjectId())) {
             projectNameCB.setSelectedItem(appSettingState.getProjectId());
+        }
+        if (StringUtils.isNotBlank(appSettingState.getProjectVersion())) {
+            projectVersionCB.setSelectedItem(appSettingState.getProjectVersion());
+        }
+        if (StringUtils.isNotBlank(appSettingState.getProjectVersion())) {
+            projectVersionCB.setSelectedItem(appSettingState.getProjectVersion());
         }
         if (appSettingState.getModuleNameList() != null) {
             appSettingState.getModuleNameList().forEach(p -> moduleNameCB.addItem(p));
@@ -105,8 +126,17 @@ public class AppSettingComponent {
             if (itemEvent.getStateChange() == ItemEvent.SELECTED) {
                 if (projectNameCB.getSelectedItem() != null && StringUtils.isNotBlank(projectNameCB.getSelectedItem().toString())) {
                     if (appSettingState.getProjectList().size() > 0) {
-                        String pId = appSettingState.getProjectList().stream().filter(p -> (p.getName().equalsIgnoreCase(itemEvent.getItem().toString()))).findFirst().get().getId();
-                        initModule(pId);
+                        MSProject selectedProject = appSettingState.getProjectList()
+                            .stream()
+                            .filter(
+                                p -> (p.getName().equalsIgnoreCase(itemEvent.getItem().toString())))
+                            .findFirst()
+                            .orElseThrow();
+                        initModule(selectedProject.getId());
+                        // 开启了版本则改变版本列表状态
+                        if(Objects.equals(true, selectedProject.getVersionEnable())) {
+                            mutationProjectVersions(selectedProject.getId());
+                        }
                     }
                 }
             }
@@ -131,6 +161,14 @@ public class AppSettingComponent {
                 appSettingState.setExportModuleName(new String(moduleName.getText().trim().getBytes(StandardCharsets.UTF_8)));
             }
         });
+        projectVersionCB.addItemListener(itemEvent -> {
+            if (itemEvent.getStateChange() == ItemEvent.SELECTED
+                && projectVersionCB.getSelectedItem() != null
+                && StringUtils.isNotBlank(projectVersionCB.getSelectedItem().toString())) {
+                String versionName = itemEvent.getItem().toString();
+                appSettingState.setProjectVersion(versionName);
+            }
+        });
         contextPath.addKeyListener(new KeyAdapter() {
             @Override
             public void keyReleased(KeyEvent e) {
@@ -139,6 +177,34 @@ public class AppSettingComponent {
         });
         javadocCheckBox.addActionListener((actionEvent) -> {
             appSettingState.setJavadoc(javadocCheckBox.isSelected());
+        });
+    }
+
+    /**
+     * 改变项目版本下拉列表的状态值
+     */
+    private void mutationProjectVersions(String projectId) {
+        CompletableFuture.runAsync(() -> {
+            AppSettingState appSettingState = appSettingService.getState();
+            if (appSettingState == null) {
+                return;
+            }
+            JSONObject jsonObject = MSApiUtil.listProjectVersionBy(projectId, appSettingState);
+            if (jsonObject != null && jsonObject.getBoolean("success")) {
+                String json = gson.toJson(jsonObject.getJSONArray("data"));
+                List<MSVersion> versionList = gson.fromJson(json, new TypeToken<List<MSVersion>>() {
+                }.getType());
+                appSettingState.setVersionOptions(versionList);
+            }
+            List<MSVersion> statedVersions = appSettingState.getVersionOptions();
+            if (CollectionUtils.isEmpty(statedVersions)) {
+                return;
+            }
+            //设置下拉选择框
+            this.projectVersionCB.removeAllItems();
+            for (MSVersion version : appSettingState.getVersionOptions()) {
+                this.projectVersionCB.addItem(version.getName());
+            }
         });
     }
 

--- a/src/main/java/org/metersphere/gui/AppSettingComponent.java
+++ b/src/main/java/org/metersphere/gui/AppSettingComponent.java
@@ -29,7 +29,7 @@ import org.metersphere.AppSettingService;
 import org.metersphere.state.AppSettingState;
 import org.metersphere.state.MSModule;
 import org.metersphere.state.MSProject;
-import org.metersphere.state.MSVersion;
+import org.metersphere.state.MSProjectVersion;
 import org.metersphere.utils.MSApiUtil;
 
 @Data
@@ -67,15 +67,12 @@ public class AppSettingComponent {
         if (appSettingState.getProjectNameList() != null) {
             appSettingState.getProjectNameList().forEach(p -> projectNameCB.addItem(p));
         }
-        if (appSettingState.getVersionOptions() != null) {
-            appSettingState.getVersionOptions()
+        if (appSettingState.getProjectVersionOptions() != null) {
+            appSettingState.getProjectVersionOptions()
                 .forEach(version -> projectVersionCB.addItem(version.getName()));
         }
         if (StringUtils.isNotBlank(appSettingState.getProjectId())) {
             projectNameCB.setSelectedItem(appSettingState.getProjectId());
-        }
-        if (StringUtils.isNotBlank(appSettingState.getProjectVersion())) {
-            projectVersionCB.setSelectedItem(appSettingState.getProjectVersion());
         }
         if (StringUtils.isNotBlank(appSettingState.getProjectVersion())) {
             projectVersionCB.setSelectedItem(appSettingState.getProjectVersion());
@@ -124,7 +121,8 @@ public class AppSettingComponent {
         });
         projectNameCB.addItemListener(itemEvent -> {
             if (itemEvent.getStateChange() == ItemEvent.SELECTED) {
-                if (projectNameCB.getSelectedItem() != null && StringUtils.isNotBlank(projectNameCB.getSelectedItem().toString())) {
+                if (projectNameCB.getSelectedItem() != null
+                    && StringUtils.isNotBlank(projectNameCB.getSelectedItem().toString())) {
                     if (appSettingState.getProjectList().size() > 0) {
                         MSProject selectedProject = appSettingState.getProjectList()
                             .stream()
@@ -192,17 +190,17 @@ public class AppSettingComponent {
             JSONObject jsonObject = MSApiUtil.listProjectVersionBy(projectId, appSettingState);
             if (jsonObject != null && jsonObject.getBoolean("success")) {
                 String json = gson.toJson(jsonObject.getJSONArray("data"));
-                List<MSVersion> versionList = gson.fromJson(json, new TypeToken<List<MSVersion>>() {
+                List<MSProjectVersion> versionList = gson.fromJson(json, new TypeToken<List<MSProjectVersion>>() {
                 }.getType());
-                appSettingState.setVersionOptions(versionList);
+                appSettingState.setProjectVersionOptions(versionList);
             }
-            List<MSVersion> statedVersions = appSettingState.getVersionOptions();
+            List<MSProjectVersion> statedVersions = appSettingState.getProjectVersionOptions();
             if (CollectionUtils.isEmpty(statedVersions)) {
                 return;
             }
             //设置下拉选择框
             this.projectVersionCB.removeAllItems();
-            for (MSVersion version : appSettingState.getVersionOptions()) {
+            for (MSProjectVersion version : appSettingState.getProjectVersionOptions()) {
                 this.projectVersionCB.addItem(version.getName());
             }
         });

--- a/src/main/java/org/metersphere/state/AppSettingState.java
+++ b/src/main/java/org/metersphere/state/AppSettingState.java
@@ -18,7 +18,7 @@ public class AppSettingState {
 
     private List<String> projectNameList;
     private List<MSProject> projectList;
-    private List<MSVersion> versionOptions;
+    private List<MSProjectVersion> projectVersionOptions;
     private String projectId;
     private String projectName;
     private String projectVersion;

--- a/src/main/java/org/metersphere/state/AppSettingState.java
+++ b/src/main/java/org/metersphere/state/AppSettingState.java
@@ -18,8 +18,10 @@ public class AppSettingState {
 
     private List<String> projectNameList;
     private List<MSProject> projectList;
+    private List<MSVersion> versionOptions;
     private String projectId;
     private String projectName;
+    private String projectVersion;
 
     private List<MSModule> moduleList;
     private List<String> moduleNameList;

--- a/src/main/java/org/metersphere/state/MSProject.java
+++ b/src/main/java/org/metersphere/state/MSProject.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class MSProject {
     private String name;
     private String id;
+    private Boolean versionEnable;
 }

--- a/src/main/java/org/metersphere/state/MSProjectVersion.java
+++ b/src/main/java/org/metersphere/state/MSProjectVersion.java
@@ -1,6 +1,5 @@
 package org.metersphere.state;
 
-import java.time.LocalDateTime;
 import lombok.Data;
 
 /**
@@ -8,7 +7,7 @@ import lombok.Data;
  * @date 2022-01-24
  */
 @Data
-public class MSVersion {
+public class MSProjectVersion {
 
     private String name;
     private String status;

--- a/src/main/java/org/metersphere/state/MSVersion.java
+++ b/src/main/java/org/metersphere/state/MSVersion.java
@@ -1,0 +1,16 @@
+package org.metersphere.state;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/**
+ * @author guqing
+ * @date 2022-01-24
+ */
+@Data
+public class MSVersion {
+
+    private String name;
+    private String status;
+    private Boolean latest;
+}


### PR DESCRIPTION
### What this PR does?
- 基于master回退了两个提交，原因是最新的两个提交无法正常运行
- 将项目中对于
```java
ApplicationManager.getApplication().getComponent(AppSettingService.class);
```
的使用统一改为了`AppSettingService.getInstance();`
实现如下
```java
  public static AppSettingService getInstance() {
      return ApplicationManager.getApplication().getService(AppSettingService.class);
  }
```
其中将原先的`getComponent` 变更为 `getService`是因为IDEA会报错如下:
```java
java.lang.Throwable: class org.metersphere.AppSettingService it is a service, use getService instead of getComponent
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:159)
	at com.intellij.serviceContainer.ComponentManagerImpl.getComponent(ComponentManagerImpl.kt:420)
	at org.metersphere.exporter.PostmanExporter.getRaw(PostmanExporter.java:761)
	at org.metersphere.exporter.PostmanExporter.lambda$transform$3(PostmanExporter.java:280)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```
- 提供了对于项目版本的配置项
Before:
![image](https://user-images.githubusercontent.com/38999863/150774349-f652c9fc-9b0e-4224-a462-0074a02c66a1.png)
After:
![image](https://user-images.githubusercontent.com/38999863/150774486-d83fd2e0-798e-47f3-b5e0-6a11e799e43c.png)

### Why we need it?
同步 metersphere 的接口功能到插件

### How to test it?
Clone 该 PR 到本地或者使用 github-cli
```java
gh pr checkout 1
```
**测试配置版本**
1. 打开项目后点击 `File -> Project Settings -> Platform Settings -> SDKs`
2. 点击 `+` 按钮选择`Add Intellij Platform Plugin SDK`后选择 IDEA 的安装目录
3. 同时需要设置 `Project`依赖的 JDK 版本为 11，而后点击 Gradle的`runIdle`运行
4. 此时 IDEA 会启动一个新的 IDEA 实例，任意打开一个 java 项目后点击 `File -> Settings -> Other Settings -> MeterSphere`即可看到配置项
更多请参考： [Code Samples](https://plugins.jetbrains.com/docs/intellij/code-samples.html)

**测试 Export MeterSphere**
打开当前项目的文件`org/metersphere/exporter/MeterSphereExporter.java`文件在 105 行打断点，而后以 Debug模式启动，待启动结束后IDEA会开启新实例以此打开一个java项目然后在项目上右键点击 `Export MeterSphere`查看断点处参数`versionId`是否正确