### PR TITLE
detect javadoc, add formal parameter, version=1.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'org.intellij.sdk'
-version '1.0.5'
+version '1.0.6'
 
 sourceCompatibility = 11
 repositories {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -94,6 +94,7 @@
         <li><b>1.0.2</b> add response support. postman export,fix map jsonobject</li>
         <li><b>1.0.3</b> fix List<Map> format error</li>
         <li><b>1.0.5</b> version support</li>
+        <li><b>1.0.6</b> detect javadoc, add formal parameter</li>
       </ul>]]></change-notes>
 
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
1. :sparkles:：识别接口方法上@param的参数描述。
2. :sparkles:：识别接口方法上的原生对象（不加@RequestParam默认为query）。
3. :hammer:：将POST请求情况下，未加@RequestParam的参数由默认json调整为form-data。
4. :zap::racehorse:：部分正则表达式调整为类常量减少编译时间。