### PR TITLE
fix: skip static field and garbled

### DIFF
--- a/src/main/java/org/metersphere/exporter/MeterSphereExporter.java
+++ b/src/main/java/org/metersphere/exporter/MeterSphereExporter.java
@@ -46,24 +46,24 @@ public class MeterSphereExporter implements IExporter {
         appSettingService.getState().setWithBasePath(false);
 
         List<PostmanModel> postmanModels = v2Exporter.transform(files, appSettingService.getState());
-        if (postmanModels.size() == 0) {
+        if (postmanModels.isEmpty()) {
             throw new RuntimeException(PluginConstants.EXCEPTIONCODEMAP.get(3));
         }
         File temp = File.createTempFile(UUID.randomUUID().toString(), null);
-        BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(temp));
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("item", postmanModels);
-        JSONObject info = new JSONObject();
-        info.put("schema", "https://schema.getpostman.com/json/collection/v2.1.0/collection.json");
-        String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        String exportName = StringUtils.isNotBlank(appSettingService.getState().getExportModuleName()) ? appSettingService.getState().getExportModuleName() : files.get(0).getProject().getName();
-        info.put("name", exportName);
-        info.put("description", "exported at " + dateTime);
-        info.put("_postman_id", UUID.randomUUID().toString());
-        jsonObject.put("info", info);
-        bufferedWriter.write(new Gson().toJson(jsonObject));
-        bufferedWriter.flush();
-        bufferedWriter.close();
+        try (BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(temp, StandardCharsets.UTF_8))) {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("item", postmanModels);
+            JSONObject info = new JSONObject();
+            info.put("schema", "https://schema.getpostman.com/json/collection/v2.1.0/collection.json");
+            String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+            String exportName = StringUtils.isNotBlank(appSettingService.getState().getExportModuleName()) ? appSettingService.getState().getExportModuleName() : files.get(0).getProject().getName();
+            info.put("name", exportName);
+            info.put("description", "exported at " + dateTime);
+            info.put("_postman_id", UUID.randomUUID().toString());
+            jsonObject.put("info", info);
+            bufferedWriter.write(new Gson().toJson(jsonObject));
+            bufferedWriter.flush();
+        }
         AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<>();
         boolean r = uploadToServer(temp, throwableAtomicReference);
         if (!r) {

--- a/src/main/java/org/metersphere/model/FieldWrapper.java
+++ b/src/main/java/org/metersphere/model/FieldWrapper.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang.StringUtils;
 import org.metersphere.AppSettingService;
 import org.metersphere.constants.ExcludeFieldConstants;
 import org.metersphere.constants.JavaTypeEnum;
+import org.metersphere.parse.utils.PsiUtils;
 import org.metersphere.state.AppSettingState;
 import org.metersphere.utils.FieldUtil;
 import org.metersphere.utils.LogUtil;
@@ -228,11 +229,8 @@ public class FieldWrapper {
             if (psiClass == null) {
                 return;
             }
-            for (PsiField psiField : psiClass.getAllFields()) {
+            for (PsiField psiField : PsiUtils.getMemberFields(psiClass)) {
                 if (ExcludeFieldConstants.skipJavaTypes.contains(psiField.getName().toLowerCase())) {
-                    continue;
-                }
-                if (FieldUtil.isStaticField(psiField)) {
                     continue;
                 }
                 if (FieldUtil.isIgnoredField(psiField)) {

--- a/src/main/java/org/metersphere/parse/utils/PsiUtils.java
+++ b/src/main/java/org/metersphere/parse/utils/PsiUtils.java
@@ -1,0 +1,53 @@
+package org.metersphere.parse.utils;
+
+import java.util.Arrays;
+
+import com.intellij.lang.jvm.JvmModifier;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiTypeParameter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * reference YApix
+ * @see <a href="https://github.com/jetplugins/yapix/blob/main/src/main/java/io/yapix/parse/util/PsiUtils.java">PsiUtils</a>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PsiUtils {
+
+	/**
+	 * get all members psiField (not contains static filed)
+	 * @param t the PsiClass
+	 * @return PsiField[]
+	 */
+	public static PsiField[] getMemberFields(PsiClass t) {
+		PsiField[] fields = t.getAllFields();
+		return Arrays.stream(fields).filter(PsiUtils::isNeedField).toArray(PsiField[]::new);
+	}
+
+	public static boolean isNeedField(PsiField field) {
+		return !field.hasModifier(JvmModifier.STATIC);
+	}
+
+	/**
+	 * find the actual type of the generic type
+	 * Note: the definitionTypeParameters must same length as the actualTypeArguments
+	 * @param psiType psiType
+	 * @param definitionTypeParameters the type parameters of the definition class
+	 * @param actualTypeParameters the actual type parameters of the runtime
+	 * @return Actual Runtime PsiType
+	 */
+	public static PsiType getGenericType(PsiType psiType, PsiTypeParameter[] definitionTypeParameters, PsiType[] actualTypeParameters) {
+		// like T
+		String defineType = psiType.getCanonicalText();
+		for (PsiTypeParameter definitionTypeParameter : definitionTypeParameters) {
+			if (defineType.equals(definitionTypeParameter.getName())) {
+				return actualTypeParameters[definitionTypeParameter.getIndex()];
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/org/metersphere/utils/FieldUtil.java
+++ b/src/main/java/org/metersphere/utils/FieldUtil.java
@@ -190,21 +190,6 @@ public class FieldUtil {
         return presentableText.startsWith("Map<") || presentableText.startsWith("HashMap<") || presentableText.startsWith("LinkedHashMap<");
     }
 
-    public static boolean isStaticField(PsiField psiField) {
-        PsiModifierList modifierList = psiField.getModifierList();
-        if (modifierList == null) {
-            return false;
-        }
-        for (PsiElement child : modifierList.getChildren()) {
-            if (child instanceof PsiKeyword) {
-                if (child.getText().equals("static")) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     public static boolean isIgnoredField(PsiField psiField) {
         PsiAnnotation[] annotations = psiField.getAnnotations();
         if (annotations.length == 0) {

--- a/src/main/java/org/metersphere/utils/FieldUtil.java
+++ b/src/main/java/org/metersphere/utils/FieldUtil.java
@@ -224,7 +224,7 @@ public class FieldUtil {
                 PsiDocToken token = iterator.next();
                 if (token.getTokenType().toString().equalsIgnoreCase("DOC_COMMENT_DATA")) {
                     if (StringUtils.isNotBlank(token.getText())) {
-                        apiName = UTF8Util.toUTF8String(token.getText()).trim();
+                        apiName = token.getText().trim();
                     }
                     break;
                 }


### PR DESCRIPTION
### static field check

The previous funcation cannot work normally, so  the new funcation is used to instead

### Chinese garbled

- PsiDocToken#getText No coding required
- Charset  should be specified when new FileWriter 