### PR TITLE
fix: 只有导出MeterSphere参数时才检查连接状态

### DIFF
--- a/src/main/java/org/metersphere/exporter/ExporterFactory.java
+++ b/src/main/java/org/metersphere/exporter/ExporterFactory.java
@@ -15,11 +15,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.metersphere.constants.PluginConstants.EXPORTER_MS;
+import static org.metersphere.constants.PluginConstants.EXPORTER_POSTMAN;
+
 public class ExporterFactory {
     private static AppSettingService appSettingService = AppSettingService.getInstance();
     private static Map<String, IExporter> exporterMap = new HashMap<>() {{
-        put(PluginConstants.EXPORTER_POSTMAN, new PostmanExporter());
-        put(PluginConstants.EXPORTER_MS, new MeterSphereExporter());
+        put(EXPORTER_POSTMAN, new PostmanExporter());
+        put(EXPORTER_MS, new MeterSphereExporter());
     }};
 
     public static boolean export(String source, AnActionEvent event) throws Throwable {
@@ -29,8 +32,11 @@ public class ExporterFactory {
         if (element == null)
             Messages.showInfoMessage("no valid psi element found!", PluginConstants.MessageTitle.Info.name());
 
-        if (!MSApiUtil.test(appSettingService.getState())) {
-            throw new RuntimeException(PluginConstants.EXCEPTIONCODEMAP.get(1));
+        if (EXPORTER_MS.equalsIgnoreCase(source)) {
+            //只有导出metersphere时才检查连接状态
+            if (!MSApiUtil.test(appSettingService.getState())) {
+                throw new RuntimeException(PluginConstants.EXCEPTIONCODEMAP.get(1));
+            }
         }
         List<PsiJavaFile> files = new LinkedList<>();
         PostmanExporter.getFile(element, files);


### PR DESCRIPTION
选择只导出postman时不必检查ak sk
![image](https://github.com/metersphere/metersphere-idea-plugin/assets/46101698/575d21da-7ca1-4dcc-9c6b-13f804ed3719)
